### PR TITLE
Upgrade Skaffold version to v1.20.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - run: |
           npm run build
       - run: |
-          npm run test          
+          npm run test
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # setup tools used by WaaS workflows
 
-This action will setup the following tools (for version `waas/v1alpha3` and `waas/v1alpha4`):
+The action to setup the tools required for WaaS.
+
+For latest version, `waas/v1alpha4`, following tools are set up.
 
 - kubectl 1.17.17
 - kustomize 3.5.4
-- skaffold 1.17.1
+- skaffold 1.20.0
 - sops 3.6.1
 - yq 3.4.1
 - SopsSecretGenerator 1.3.0
@@ -13,7 +15,7 @@ This action will setup the following tools (for version `waas/v1alpha3` and `waa
 
 ### `version`
 
-**Required** waas schema version (e.g. `waas/v1alpha3`) for which tools should set up.
+**Required** WaaS schema version for which tools should be set up.
 
 ## Outputs
 
@@ -21,7 +23,7 @@ This action will setup the following tools (for version `waas/v1alpha3` and `waa
 ## Example usage
 
 ```yaml
-uses: metro-digital/setup-tools-for-waas
+uses: metro-digital/setup-tools-for-waas@v0.x
 with:
-    version: 'waas/v1alpha3'
+    version: 'waas/v1alpha4'
 ```

--- a/dist/waas.v1alpha3.yaml
+++ b/dist/waas.v1alpha3.yaml
@@ -1,20 +1,20 @@
-- 
+-
   name: kubectl
   version: 1.17.17
   url: https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/linux/amd64/kubectl
-- 
+-
   name: sops
   version: 3.6.1
   url: https://github.com/mozilla/sops/releases/download/v3.6.1/sops-v3.6.1.linux
-- 
+-
   name: yq
   version: 3.4.1
   url: https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
-- 
+-
   name: kustomize
   version: 3.5.4
   url: https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz
-- 
+-
   name: skaffold
   version: 1.17.1
   url: https://github.com/GoogleContainerTools/skaffold/releases/download/v1.17.1/skaffold-linux-amd64

--- a/dist/waas.v1alpha4.yaml
+++ b/dist/waas.v1alpha4.yaml
@@ -1,23 +1,23 @@
-- 
+-
   name: kubectl
   version: 1.17.17
   url: https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/linux/amd64/kubectl
-- 
+-
   name: sops
   version: 3.6.1
   url: https://github.com/mozilla/sops/releases/download/v3.6.1/sops-v3.6.1.linux
-- 
+-
   name: yq
   version: 3.4.1
   url: https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
-- 
+-
   name: kustomize
   version: 3.5.4
   url: https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz
-- 
+-
   name: skaffold
-  version: 1.17.1
-  url: https://github.com/GoogleContainerTools/skaffold/releases/download/v1.17.1/skaffold-linux-amd64
+  version: 1.20.0
+  url: https://github.com/GoogleContainerTools/skaffold/releases/download/v1.20.0/skaffold-linux-amd64
 -
   name: SopsSecretGenerator
   version: 1.3.0

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -69,11 +69,11 @@ describe('installer tests', () => {
     expectRightVersion(tool, './kustomize version')
   })
 
-  it('Acquires skaffold version 1.17.1', async () => {
+  it('Acquires skaffold version 1.20.0', async () => {
     const tool = {
       name: 'skaffold',
-      version: '1.17.1',
-      url: `https://github.com/GoogleContainerTools/skaffold/releases/download/v1.17.1/skaffold-${process.platform}-amd64`
+      version: '1.20.0',
+      url: `https://github.com/GoogleContainerTools/skaffold/releases/download/v1.20.0/skaffold-${process.platform}-amd64`
     }
     await install.downloadTool(tool)
 


### PR DESCRIPTION
The github workflow generated for waas/v1alpha4 uses "skaffold build" command to build and push the container image to container registry where we are using "ignoreChanges" option under "tagPolicy" in Sakffold configuration file which needs v1.20.0 of Skaffold binary.