### PR TITLE
feat(action): support waas/v1beta1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7677,6 +7677,7 @@ const core = __importStar(__webpack_require__(470));
 const fs = __importStar(__webpack_require__(747));
 const yaml = __importStar(__webpack_require__(414));
 const path = __importStar(__webpack_require__(622));
+const supportedVersions = ['waas/v1alpha3', 'waas/v1alpha4', 'waas/v1beta1'];
 function loadConfig(version) {
     if (version === 'waas/v1alpha1') {
         // nothing for the moment
@@ -7684,7 +7685,7 @@ function loadConfig(version) {
     else if (version === 'waas/v1alpha2') {
         // nothing for the moment
     }
-    else if (version === 'waas/v1alpha3' || version === 'waas/v1alpha4') {
+    else if (supportedVersions.includes(version)) {
         const configFilepath = path.join(__dirname, `${version.replace('/', '.')}.yaml`);
         core.debug(`Reading config from ${configFilepath}`);
         return yaml.load(fs.readFileSync(configFilepath, 'utf8'));

--- a/dist/waas.v1beta1.yaml
+++ b/dist/waas.v1beta1.yaml
@@ -1,0 +1,29 @@
+-
+  name: kubectl
+  version: 1.17.17
+  url: https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/linux/amd64/kubectl
+-
+  name: sops
+  version: 3.6.1
+  url: https://github.com/mozilla/sops/releases/download/v3.6.1/sops-v3.6.1.linux
+-
+  name: yq
+  version: 3.4.1
+  url: https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+-
+  name: kustomize
+  version: 3.5.4
+  url: https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz
+-
+  name: skaffold
+  version: 1.20.0
+  url: https://github.com/GoogleContainerTools/skaffold/releases/download/v1.20.0/skaffold-linux-amd64
+-
+  name: SopsSecretGenerator
+  version: 1.3.2
+  url: https://github.com/goabout/kustomize-sopssecretgenerator/releases/download/v1.3.2/SopsSecretGenerator_1.3.2_linux_amd64
+  dest: ${XDG_CONFIG_HOME:-$HOME/.config}/kustomize/plugin/goabout.com/v1beta1/sopssecretgenerator
+-
+  name: kenv
+  version: 1.0.2
+  url: https://github.com/metro-digital/kenv/releases/download/v1.0.2/kenv.linux.amd64

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "setup-tools-for-waas",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,12 +12,14 @@ export type Tool = {
 
 export type Tools = Tool[]
 
+const supportedVersions = ['waas/v1alpha3', 'waas/v1alpha4', 'waas/v1beta1']
+
 export function loadConfig (version: string): Tools {
   if (version === 'waas/v1alpha1') {
     // nothing for the moment
   } else if (version === 'waas/v1alpha2') {
     // nothing for the moment
-  } else if (version === 'waas/v1alpha3' || version === 'waas/v1alpha4') {
+  } else if (supportedVersions.includes(version)) {
     const configFilepath = path.join(__dirname, `${version.replace('/', '.')}.yaml`)
     core.debug(`Reading config from ${configFilepath}`)
     return yaml.load(fs.readFileSync(configFilepath, 'utf8')

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -34,6 +34,21 @@ describe('config tests', () => {
     expect(tools[0].url).toEqual('https://source.com/sops')
   })
 
+  it('Loads the config for version waas/v1beta1', async () => {
+    const tool = [{
+      name: 'sops',
+      version: '3.6.1',
+      url: 'https://source.com/sops'
+    }]
+
+    fs.readFileSync = jest.fn().mockReturnValue(yaml.dump(tool))
+    const tools = config.loadConfig('waas/v1beta1')
+
+    expect(tools[0].name).toEqual('sops')
+    expect(tools[0].version).toEqual('3.6.1')
+    expect(tools[0].url).toEqual('https://source.com/sops')
+  })
+
   it('Throws an error for the unsupported version', async () => {
     let error = null
 


### PR DESCRIPTION
This isn't the final version of the action, because it is currently
missing the download of the new kustomize plugin for GCP secrets.
But because this plugin is already installed on our self-hosted runners,
it can be used with SHRs