### PR TITLE
Install v1.1.0 of kenv for waas/v2alpha1

### DIFF
--- a/dist/waas.v2alpha1.yaml
+++ b/dist/waas.v2alpha1.yaml
@@ -25,8 +25,8 @@
   dest: ${XDG_CONFIG_HOME:-$HOME/.config}/kustomize/plugin/goabout.com/v1beta1/sopssecretgenerator
 -
   name: kenv
-  version: 1.0.2
-  url: https://github.com/metro-digital/kenv/releases/download/v1.0.2/kenv.linux.amd64
+  version: 1.1.0
+  url: https://github.com/metro-digital/kenv/releases/download/v1.1.0/kenv.linux.amd64
 -
   name: KGCPSecret
   version: 1.0.3


### PR DESCRIPTION
To use latest version of Kenv so that it is compatible with the version of Kustomize used.